### PR TITLE
Ensure we have a test venv created using virtualenv < 13.0

### DIFF
--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -1,12 +1,36 @@
-{{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}:
+{%- set virtualenv_base = salt['runtests_helpers.get_salt_temp_dir_for_path']('virtualenv-12-base') -%}
+{%- set virtualenv_test = salt['runtests_helpers.get_salt_temp_dir_for_path']('pip-installed-weird-install') -%}
+
+{{ virtualenv_base }}:
   virtualenv.managed:
     - system_site_packages: False
     - distribute: True
+
+install_older_venv:
+  pip.installed:
+    - name: 'virtualenv < 13.0'
+    - bin_env: {{ virtualenv_base }}
+    - require:
+      - virtualenv: {{ virtualenv_base }}
+
+# For this test we need to make sure that the virtualenv used in the
+# 'carbon-weird-setup' pip.installed state below was created using
+# virtualenv < 13.0. virtualenvs created using later versions make
+# packages with custom setuptools prefixes relative to the virtualenv
+# itself, which makes the 'weird' behavior we are trying to confirm
+# obsolete. Thus, the two states above ensure that the 'base' venv has
+# a version old enough to exhibit the behavior we want to test.
+
+setup_test_virtualenv:
+  cmd.run:
+    - name: {{ virtualenv_base }}/bin/virtualenv {{ virtualenv_test }}
+    - onchanges:
+      - pip: install_older_venv
 
 carbon-weird-setup:
   pip.installed:
     - name: carbon
     - no_deps: True
-    - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
-    - require:
-      - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
+    - bin_env: {{ virtualenv_test }}
+    - onchanges:
+      - cmd: setup_test_virtualenv

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -9,6 +9,7 @@
 
 # Import python libs
 from __future__ import absolute_import
+import errno
 import os
 import pwd
 import glob
@@ -82,8 +83,6 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         # If so, skip this test.
         if grains['os'] in ('CentOS',) and grains['osrelease_info'][0] in (5,):
             self.skipTest('This test does not run reliably on CentOS 5')
-        if grains['os'] in ('MacOS',):
-            self.skipTest('This test does not run reliably on MacOS')
 
         ographite = '/opt/graphite'
         if os.path.isdir(ographite):
@@ -94,7 +93,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         try:
             os.makedirs(ographite)
         except OSError as err:
-            if err.errno == 13:
+            if err.errno == errno.EACCES:
                 # Permission denied
                 self.skipTest(
                     'You don\'t have the required permissions to run this test'
@@ -103,10 +102,12 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             if os.path.isdir(ographite):
                 shutil.rmtree(ographite)
 
-        venv_dir = os.path.join(
-            integration.SYS_TMP_DIR, 'pip-installed-weird-install'
-        )
+        venv_dir = os.path.join(integration.TMP, 'pip-installed-weird-install')
         try:
+            # We may be able to remove this, I had to add it because the custom
+            # modules from the test suite weren't available in the jinja
+            # context when running the call to state.sls that comes after.
+            self.run_function('saltutil.sync_modules')
             # Since we don't have the virtualenv created, pip.installed will
             # thrown and error.
             ret = self.run_function(
@@ -118,16 +119,17 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # some of the state return parts
             for key in six.iterkeys(ret):
                 self.assertTrue(ret[key]['result'])
-                if ret[key]['comment'] == 'Created new virtualenv':
+                if ret[key]['name'] != 'carbon':
                     continue
                 self.assertEqual(
                     ret[key]['comment'],
                     'There was no error installing package \'carbon\' '
                     'although it does not show when calling \'pip.freeze\'.'
                 )
+                break
+            else:
+                raise Exception('Expected state did not run')
         finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
             if os.path.isdir('/opt/graphite'):
                 shutil.rmtree('/opt/graphite')
 


### PR DESCRIPTION
The test that runs these states is testing for behavior that was
obsoleted by virtualenv 13.0. Ensure that we have older virtualenv
available, and then create a venv with that older version. Use the
2nd virtualenv to attempt the "weird" install.